### PR TITLE
Fix deploy workflow to trigger on master branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [master]
 
 permissions:
   contents: read


### PR DESCRIPTION
The workflow was configured to trigger on pushes to "main", but the default branch is "master", so auto-deploy never fired.

https://claude.ai/code/session_01KJyzcyxfq3VxKDTFEmUc6t