### PR TITLE
Fix service page by renaming JSON keys to match page expectations

### DIFF
--- a/src/data/service.json
+++ b/src/data/service.json
@@ -1,5 +1,5 @@
 {
-  "organisationalContributions": [
+  "leadership": [
     {
       "role": "Co-chair of the SIGHCI group",
       "organization": "Dutch National Computer Science Association (IPN)",
@@ -91,7 +91,7 @@
       "years": "2013–2019"
     }
   ],
-  "conferenceOrganisation": [
+  "initiatives": [
     {
       "role": "Paper co-Chair",
       "venue": "CHI 2026",


### PR DESCRIPTION
Renamed `organisationalContributions` → `leadership` and `conferenceOrganisation` → `initiatives` so the ServicePage component can find and render all sections.

https://claude.ai/code/session_01DupKQgjDLUKzAaZf42BYNx