### PR TITLE
fix: remove redundant section divider between hero and highlights

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -126,10 +126,8 @@ export default function HomePage() {
         </div>
       </section>
 
-      <SectionDivider />
-
       {/* Highlights */}
-      <section className="container mx-auto px-4 py-20" aria-labelledby="highlights-heading">
+      <section className="container mx-auto px-4 py-16" aria-labelledby="highlights-heading">
         <motion.div initial="hidden" animate="show" variants={stagger}>
           <SectionHeader title="Highlights" id="highlights-heading" />
           <ul className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3 list-none p-0">


### PR DESCRIPTION
The hero gradient already provides a clear visual break, so the SectionDivider was adding unnecessary whitespace. Also reduced highlights padding from py-20 to py-16.

https://claude.ai/code/session_01F3DhpR6MAutMszuUQjLPgJ