### PR TITLE
feat: add paper, graduation, and event news type icons

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import {
   ArrowRight, BookOpen, ExternalLink, GraduationCap,
   Award, Building2, Brain, Library, Trophy, Globe, Sparkles,
-  Calendar, Mic, Newspaper, Gift
+  Calendar, Mic, Newspaper, Gift, FileText, GraduationCap as GradCap, CalendarDays
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -28,6 +28,9 @@ const newsIconMap: Record<string, React.ReactNode> = {
   keynote: <Mic className="h-3 w-3" aria-hidden="true" />,
   media: <Newspaper className="h-3 w-3" aria-hidden="true" />,
   grant: <Gift className="h-3 w-3" aria-hidden="true" />,
+  paper: <FileText className="h-3 w-3" aria-hidden="true" />,
+  graduation: <GradCap className="h-3 w-3" aria-hidden="true" />,
+  event: <CalendarDays className="h-3 w-3" aria-hidden="true" />,
 };
 
 const stagger = {

--- a/src/pages/NewsPage.tsx
+++ b/src/pages/NewsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { motion } from 'framer-motion';
-import { Award, Mic, Newspaper, Gift, Calendar } from 'lucide-react';
+import { Award, Mic, Newspaper, Gift, Calendar, FileText, GraduationCap, CalendarDays } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import newsData from '@/data/news.json';
@@ -12,6 +12,9 @@ const typeIcons: Record<string, React.ReactNode> = {
   keynote: <Mic className="h-4 w-4" aria-hidden="true" />,
   media: <Newspaper className="h-4 w-4" aria-hidden="true" />,
   grant: <Gift className="h-4 w-4" aria-hidden="true" />,
+  paper: <FileText className="h-4 w-4" aria-hidden="true" />,
+  graduation: <GraduationCap className="h-4 w-4" aria-hidden="true" />,
+  event: <CalendarDays className="h-4 w-4" aria-hidden="true" />,
 };
 
 const fadeUp = { hidden: { opacity: 0, y: 20 }, show: { opacity: 1, y: 0, transition: { duration: 0.4 } } };


### PR DESCRIPTION
New icon mappings in both HomePage and NewsPage:
- paper → FileText (accepted publications)
- graduation → GraduationCap (PhD/Master graduations)
- event → CalendarDays (organised events)

https://claude.ai/code/session_01F3DhpR6MAutMszuUQjLPgJ