### PR TITLE
feat: split Teaching page into Teaching and Supervision pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import ResearchPage from "./pages/ResearchPage";
 import PublicationsPage from "./pages/PublicationsPage";
 import ProjectsPage from "./pages/ProjectsPage";
 import TeachingPage from "./pages/TeachingPage";
+import SupervisionPage from "./pages/SupervisionPage";
 import ServicePage from "./pages/ServicePage";
 import NewsPage from "./pages/NewsPage";
 import ContactPage from "./pages/ContactPage";
@@ -33,6 +34,7 @@ const App = () => (
               <Route path="/publications" element={<PublicationsPage />} />
               <Route path="/projects" element={<ProjectsPage />} />
               <Route path="/teaching" element={<TeachingPage />} />
+              <Route path="/supervision" element={<SupervisionPage />} />
               <Route path="/service" element={<ServicePage />} />
               <Route path="/news" element={<NewsPage />} />
               <Route path="/contact" element={<ContactPage />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,7 @@ const navGroups = [
   {
     items: [
       { label: 'Teaching', path: '/teaching' },
+      { label: 'Supervision', path: '/supervision' },
       { label: 'Service', path: '/service' },
     ],
   },

--- a/src/pages/SupervisionPage.tsx
+++ b/src/pages/SupervisionPage.tsx
@@ -1,0 +1,70 @@
+import { motion } from 'framer-motion';
+import { Users, FlaskConical } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import supervisionData from '@/data/supervision.json';
+import type { Supervision } from '@/types';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+
+const fadeUp = { hidden: { opacity: 0, y: 20 }, show: { opacity: 1, y: 0, transition: { duration: 0.5 } } };
+const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.08 } } };
+
+function SupervisionCard({ s }: { s: Supervision }) {
+  return (
+    <motion.div variants={fadeUp}
+      className="flex flex-col gap-1 rounded-lg border bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-xs text-muted-foreground">{s.years}</span>
+        </div>
+        {s.name && <p className="font-sans text-sm font-semibold">{s.name}</p>}
+        <p className="text-sm text-muted-foreground">{s.topic}</p>
+        {s.coSupervisors.length > 0 && (
+          <p className="text-xs text-muted-foreground">Co-supervised with: {s.coSupervisors.join(', ')}</p>
+        )}
+      </div>
+      {s.outcome && (
+        <p className="text-xs text-primary font-medium shrink-0">{s.outcome}</p>
+      )}
+    </motion.div>
+  );
+}
+
+export default function SupervisionPage() {
+  useDocumentTitle('Supervision');
+  const rawSupervision = supervisionData as Supervision[] | { default: Supervision[] };
+  const supervision: Supervision[] = 'default' in rawSupervision ? rawSupervision.default : rawSupervision;
+
+  const phdCandidates = supervision.filter(s => s.level === 'PhD');
+  const postdocResearchers = supervision.filter(s => s.level === 'Postdoc');
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1 className="mb-2 font-display text-3xl font-bold md:text-4xl">Supervision</h1>
+      <p className="mb-10 text-muted-foreground">PhD candidates and postdoc researchers.</p>
+
+      {/* PhD Candidates */}
+      <section className="mb-12" aria-labelledby="phd-heading">
+        <h2 id="phd-heading" className="mb-6 flex items-center gap-2 font-display text-2xl font-semibold">
+          <Users className="h-6 w-6 text-primary" aria-hidden="true" /> PhD Candidates
+        </h2>
+        <motion.div initial="hidden" animate="show" variants={stagger} className="space-y-3">
+          {phdCandidates.map((s, i) => (
+            <SupervisionCard key={i} s={s} />
+          ))}
+        </motion.div>
+      </section>
+
+      {/* Postdoc Researchers */}
+      <section aria-labelledby="postdoc-heading">
+        <h2 id="postdoc-heading" className="mb-6 flex items-center gap-2 font-display text-2xl font-semibold">
+          <FlaskConical className="h-6 w-6 text-primary" aria-hidden="true" /> Postdoc Researchers
+        </h2>
+        <motion.div initial="hidden" animate="show" variants={stagger} className="space-y-3">
+          {postdocResearchers.map((s, i) => (
+            <SupervisionCard key={i} s={s} />
+          ))}
+        </motion.div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/TeachingPage.tsx
+++ b/src/pages/TeachingPage.tsx
@@ -1,29 +1,25 @@
 import { motion } from 'framer-motion';
-import { ExternalLink, GraduationCap, Users } from 'lucide-react';
+import { ExternalLink, GraduationCap } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import coursesData from '@/data/teaching.json';
-import supervisionData from '@/data/supervision.json';
-import type { Course, Supervision } from '@/types';
+import type { Course } from '@/types';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 
 const fadeUp = { hidden: { opacity: 0, y: 20 }, show: { opacity: 1, y: 0, transition: { duration: 0.5 } } };
 const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.08 } } };
 
 export default function TeachingPage() {
-  useDocumentTitle('Teaching & Supervision');
+  useDocumentTitle('Teaching');
   const rawCourses = coursesData as Course[] | { default: Course[] };
   const courses: Course[] = 'default' in rawCourses ? rawCourses.default : rawCourses;
-  const rawSupervision = supervisionData as Supervision[] | { default: Supervision[] };
-  const supervision: Supervision[] = 'default' in rawSupervision ? rawSupervision.default : rawSupervision;
 
   return (
     <div className="container mx-auto px-4 py-12">
-      <h1 className="mb-2 font-display text-3xl font-bold md:text-4xl">Teaching & Supervision</h1>
-      <p className="mb-10 text-muted-foreground">Courses, seminars, and research supervision.</p>
+      <h1 className="mb-2 font-display text-3xl font-bold md:text-4xl">Teaching</h1>
+      <p className="mb-10 text-muted-foreground">Courses and seminars.</p>
 
-      {/* Courses */}
-      <section className="mb-12" aria-labelledby="courses-heading">
+      <section aria-labelledby="courses-heading">
         <h2 id="courses-heading" className="mb-6 flex items-center gap-2 font-display text-2xl font-semibold">
           <GraduationCap className="h-6 w-6 text-primary" aria-hidden="true" /> Courses
         </h2>
@@ -45,34 +41,6 @@ export default function TeachingPage() {
                 </Button>
               ))}
             </motion.article>
-          ))}
-        </motion.div>
-      </section>
-
-      {/* Supervision */}
-      <section aria-labelledby="supervision-heading">
-        <h2 id="supervision-heading" className="mb-6 flex items-center gap-2 font-display text-2xl font-semibold">
-          <Users className="h-6 w-6 text-primary" aria-hidden="true" /> Supervision
-        </h2>
-        <motion.div initial="hidden" animate="show" variants={stagger} className="space-y-3">
-          {supervision.map((s, i) => (
-            <motion.div key={i} variants={fadeUp}
-              className="flex flex-col gap-1 rounded-lg border bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <div className="flex items-center gap-2 mb-1">
-                  <Badge variant="outline" className="text-xs">{s.level}</Badge>
-                  <span className="text-xs text-muted-foreground">{s.years}</span>
-                </div>
-                {s.name && <p className="font-sans text-sm font-semibold">{s.name}</p>}
-                <p className="text-sm text-muted-foreground">{s.topic}</p>
-                {s.coSupervisors.length > 0 && (
-                  <p className="text-xs text-muted-foreground">Co-supervised with: {s.coSupervisors.join(', ')}</p>
-                )}
-              </div>
-              {s.outcome && (
-                <p className="text-xs text-primary font-medium shrink-0">{s.outcome}</p>
-              )}
-            </motion.div>
           ))}
         </motion.div>
       </section>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig(({ mode }) => ({
         "/publications",
         "/projects",
         "/teaching",
+        "/supervision",
         "/service",
         "/news",
         "/contact",


### PR DESCRIPTION
- TeachingPage now only shows the Courses section
- New SupervisionPage with PhD Candidates and Postdoc Researchers sections
- Added /supervision route, nav link, and prerender config

https://claude.ai/code/session_01F3DhpR6MAutMszuUQjLPgJ