### PR TITLE
feat: show month/year only for news dates, orange underline for awards

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -180,10 +180,10 @@ export default function HomePage() {
                       <div className="mb-1 flex items-center gap-2">
                         <Badge className="bg-warm/10 text-warm hover:bg-warm/20 border-0 text-xs capitalize">{item.type}</Badge>
                         <time className="text-xs text-muted-foreground" dateTime={item.date}>
-                          {new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                          {new Date(item.date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
                         </time>
                       </div>
-                      <h3 className="mb-1 font-sans text-sm font-semibold text-foreground">{item.title}</h3>
+                      <h3 className={`mb-1 font-sans text-sm font-semibold text-foreground${item.type === 'award' ? ' underline decoration-orange-500 decoration-2 underline-offset-2' : ''}`}>{item.title}</h3>
                       <p className="text-sm text-muted-foreground">
                         {item.description}
                         {item.link && (

--- a/src/pages/NewsPage.tsx
+++ b/src/pages/NewsPage.tsx
@@ -58,9 +58,9 @@ export default function NewsPage() {
             <div className="rounded-lg border bg-card p-4">
               <div className="mb-1 flex items-center gap-2">
                 <Badge variant="secondary" className="text-xs capitalize">{item.type}</Badge>
-                <time className="text-xs text-muted-foreground" dateTime={item.date}>{new Date(item.date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</time>
+                <time className="text-xs text-muted-foreground" dateTime={item.date}>{new Date(item.date).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}</time>
               </div>
-              <h3 className="font-sans text-sm font-semibold">{item.title}</h3>
+              <h3 className={`font-sans text-sm font-semibold${item.type === 'award' ? ' underline decoration-orange-500 decoration-2 underline-offset-2' : ''}`}>{item.title}</h3>
               <p className="text-sm text-muted-foreground">
                 {item.description}
                 {item.link && (


### PR DESCRIPTION
- Remove day from news date display on both HomePage and NewsPage
- Award-type news titles get an orange underline for emphasis

https://claude.ai/code/session_01F3DhpR6MAutMszuUQjLPgJ